### PR TITLE
Typo fix in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ const redirectsPlugin = require('eleventy-plugin-redirects');
 
 module.exports = function(eleventyConfig) {
   eleventyConfig.addPlugin(redirectsPlugin, {
-    template: 'netlify'; // netlify, vercel or clientSide
+    template: 'netlify' // netlify, vercel or clientSide
   })
 }
 ```


### PR DESCRIPTION
There was a semicolon inside the configuration object, which is just a syntax error. (A comma could go there, but isn't required.)