### PR TITLE
Change collection retrieval to get all pages

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -10,7 +10,7 @@ module.exports = {
     const { template = 'netlify' } = options;
 
     config.addCollection('redirects', (collection) => {
-      const pages = collection.getFilteredByGlob('./src/**/*.md');
+      const pages = collection.getAll();
       const aliases = pages.map((page) => {
         if (!page.data.aliases) return null;
         return page.data.aliases.map((alias) => ({


### PR DESCRIPTION
This changes the pages collection used so that the plugin works with anything that eleventy considers a page, including .html files and top-level files.

I tested this locally with my site.

Fixes #1