### PR TITLE
Allow defining redirects via configuration

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -7,7 +7,7 @@ const {
 module.exports = {
   initArguments: {},
   configFunction: (config, options = {}) => {
-    const { template = 'netlify' } = options;
+    const { template = 'netlify', redirects = {} } = options;
 
     config.addCollection('redirects', (collection) => {
       const pages = collection.getFilteredByGlob('./src/**/*.md');
@@ -19,8 +19,12 @@ module.exports = {
           title: page.data.title,
         }));
       });
+      const configRedirects = Object.entries(redirects).map(([from, to]) => ({
+        from,
+        to,
+      }));
 
-      return aliases.filter(Boolean).flat();
+      return aliases.filter(Boolean).flat().concat(configRedirects);
     });
 
     config.addShortcode('redirects', (redirects) => {

--- a/README.md
+++ b/README.md
@@ -49,6 +49,22 @@ aliases:
 ---
 ```
 
+Additionally, redirects may be defined via configuration:
+
+```
+const redirectsPlugin = require('eleventy-plugin-redirects');
+
+module.exports = function(eleventyConfig) {
+  eleventyConfig.addPlugin(redirectsPlugin, {
+    template: 'netlify', // netlify, vercel or clientSide
+    redirects: {
+      '/old.pdf': '/new.pdf',
+      '/cool-project/': 'https://www.example.com/',
+    }
+  })
+}
+```
+
 ## Creating a redirects file 
 
 ### Netlify/Vercel

--- a/templates.js
+++ b/templates.js
@@ -20,7 +20,7 @@ const clientSideTemplate = (redirect) => `
 <!DOCTYPE html>
 <html>
   <head>
-    <title>${redirect.title}</title><link rel="canonical" href="${redirect.to}"/><meta name="robots" content="noindex"><meta charset="utf-8"/><meta http-equiv="refresh" content="0; url=${redirect.to}"/>
+    <title>${redirect.title || 'Redirecting...'}</title><link rel="canonical" href="${redirect.to}"/><meta name="robots" content="noindex"><meta charset="utf-8"/><meta http-equiv="refresh" content="0; url=${redirect.to}"/>
   </head>
 </html>
 `;


### PR DESCRIPTION
This adds support for a new `redirects` config object for cases where you can't edit the frontmater of the destination, either because it's offisite, or because it's a format that doesn't take kindly to front-matter, such as a .pdf file.

I think it will merge cleanly with the other PRs that I opened.